### PR TITLE
Add text limit in project Card ("read more" and "show less" button added)

### DIFF
--- a/src/components/projects/Card.jsx
+++ b/src/components/projects/Card.jsx
@@ -1,6 +1,13 @@
-import React from "react";
+import React, { useState } from "react";
 
 const Card = ({project, index}) => {
+
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  const handleToggle = () =>{
+    setIsExpanded(!isExpanded);
+  }
+
   return (
     <div key={index} className="project__card">
       <div className="project__thumb">
@@ -18,7 +25,10 @@ const Card = ({project, index}) => {
       <div className="project__details">
         <h3 className="project__title">{project.title}</h3>
         <div className="project__meta">
-          <span>{project.description}</span>
+          <span>
+            {isExpanded ? `${project.description}     `  : `${project.description.substring(0, 55)}...`}
+            <button onClick={handleToggle} className="read-more-btn">{isExpanded ? " show less" : " read more"}</button>
+          </span>
         </div>
         <div className="project__dot">
           {project.tags.map((tag, i) => (

--- a/src/components/projects/projects.css
+++ b/src/components/projects/projects.css
@@ -125,8 +125,6 @@ body {
 
 /* Options for Project types */
 
-/* From Uiverse.io by Shoh2008 */ 
-
 .project_types{
   margin: 50px auto;
 }
@@ -173,4 +171,13 @@ body {
   display: inline-block;
   text-align: center;
   width: 100%;
+}
+
+
+/* Read more button */
+
+.read-more-btn
+{
+  background-color: transparent;
+  color: grey;
 }


### PR DESCRIPTION
In the Card component of the project portfolio, implement functionality to expand and collapse the project description with a text limit. The feature should allow users to see a truncated version of the description initially, with the option to expand it to view the full text. Additionally, clicking anywhere outside the card should collapse the description back to its truncated form.

Requirements:

Initial Truncated Text:

Display only the first 55 characters of the project description followed by an ellipsis (...) if the description exceeds this length.
Include a "Read More" button next to the truncated text.
Expanded Text:

When the "Read More" button is clicked, show the full description and change the button text to "Show Less."
Clicking "Show Less" should collapse the description back to its truncated form.
Click Outside to Collapse:

Implement functionality such that clicking anywhere outside the card component collapses the expanded description, if it is currently open.

React Hooks: Utilize useState for managing the expanded/collapsed state.

CSS: Ensure that the "Read More" and "Show Less" buttons are styled appropriately and do not disrupt the layout of the card.